### PR TITLE
Fix packages.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -31,7 +31,9 @@
   <build_depend>shape_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
+  <build_depend>rclcpp</build_depend>
 
+  <exec_depend>rclcpp</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>assimp</exec_depend>
   <exec_depend>boost</exec_depend>
@@ -45,6 +47,9 @@
   <exec_depend>shape_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Same as the title.  The original one omits rclcpp and gtests in packages.xml, which can cause find_package failures.